### PR TITLE
Prevent empty  json _uid proprety to halt visit parsing

### DIFF
--- a/src/Oro/Bundle/TrackingBundle/Processor/TrackingProcessor.php
+++ b/src/Oro/Bundle/TrackingBundle/Processor/TrackingProcessor.php
@@ -504,6 +504,20 @@ class TrackingProcessor implements LoggerAwareInterface
             $decodedData = json_decode($eventData->getData(), true);
 
             $trackingVisit = $this->getTrackingVisit($event, $decodedData);
+            
+            if(empty($trackingVisit->getVisitorUid())) {
+                $this->logger->notice(
+                    sprintf(
+                        '<error>Visit event %s data have a null visitorUID</error>',
+                        $event->getId()
+                    )
+                );
+
+                $event->setParsed(true);
+                continue;
+            }
+            
+            
             $trackingVisitEvent->setVisit($trackingVisit);
             $trackingVisitEvent->setWebEvent($event);
             $trackingVisitEvent->setWebsite($event->getWebsite());

--- a/src/Oro/Bundle/TrackingBundle/Processor/TrackingProcessor.php
+++ b/src/Oro/Bundle/TrackingBundle/Processor/TrackingProcessor.php
@@ -508,7 +508,7 @@ class TrackingProcessor implements LoggerAwareInterface
             if(empty($trackingVisit->getVisitorUid())) {
                 $this->logger->notice(
                     sprintf(
-                        '<error>Visit event %s data have a null visitorUID</error>',
+                        '<error>Visit event %s data have a empty visitorUID</error>',
                         $event->getId()
                     )
                 );
@@ -516,7 +516,6 @@ class TrackingProcessor implements LoggerAwareInterface
                 $event->setParsed(true);
                 continue;
             }
-            
             
             $trackingVisitEvent->setVisit($trackingVisit);
             $trackingVisitEvent->setWebEvent($event);


### PR DESCRIPTION
When a empty/null `_uid` parameter is provided, the parser stop with  the following error


```
console.ERROR: An error occurred while running command "'oro:cron:tracking:parse'". An exception occurred while executing 'INSERT INTO oro_tracking_visit (serialized_data, visitor_uid, user_identifier, first_action_time, last_action_time, parsed_uid, identifier_detected, parsing_count, ip, client, client_version, client_type, os, os_version, desktop, mobile, bot, website_id, b2b_customer_72b5c170_id, customer_7c2d0d96_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params \["Tjs=", null, "", "2018-12-20 15:41:45", "2018-12-20 15:42:23", 1, 0, 0, "255.255.255.255", "Mobile Safari", "12.0", "browser", "iOS", "12.1", 0, 1, 0, 1, null, null\]:

Integrity constraint violation: 1048 Column 'visitor_uid' cannot be null \["exit_code" => 1,"exception" => Doctrine\\DBAL\\Exception\\NotNullConstraintViolationException { …},"arguments" => \["command" => "oro:cron:tracking:parse"\]\] \["processor" => "Oro\\Bundle\\CronBundle\\Async\\CommandRunnerMessageProcessor","message_id" => "oro.5ceb204cde9c94.47220755","message_body" => "{"command":"oro:cron:tracking:parse","arguments":\[\]}","message_properties" => \["oro.message_queue.client.topic_name" => "oro.cron.run_command","oro.message_queue.client.processor_name" => "oro_cron.async.command_runner_message_processor","oro.message_queue.client.queue_name" => "oro.default"\],"message_headers" => \["content_type" => "application/json","message_id" => "oro.5ceb204cde9c94.47220755","timestamp" => 1558913100\],"message_priority" => 2,"job_id" => 6008194,"job_name" => "oro:cron:run_command:oro:cron:tracking:parse","job_data" => \[\],"elapsed_time" => "1321 ms","memory_usage" => "67.96 MB"\]
```