### PR TITLE
Optimize count query in MarketingActivityRepository

### DIFF
--- a/src/Oro/Bundle/MarketingActivityBundle/Entity/Repository/MarketingActivityRepository.php
+++ b/src/Oro/Bundle/MarketingActivityBundle/Entity/Repository/MarketingActivityRepository.php
@@ -63,15 +63,21 @@ class MarketingActivityRepository extends EntityRepository
      */
     public function getMarketingActivitySummaryCountByCampaign($campaignId)
     {
-        return (bool) $this->getEntityManager()
-            ->createQueryBuilder()
-            ->select('COUNT(ma.id)')
-            ->from('OroMarketingActivityBundle:MarketingActivity', 'ma')
-            ->where('ma.campaign = :campaignId')
-            ->setParameter(':campaignId', $campaignId)
-            ->getQuery()
-            ->getSingleScalarResult();
+        try {
+            return (bool)$this->getEntityManager()
+                ->createQueryBuilder()
+                ->select('ma.id')
+                ->from('OroMarketingActivityBundle:MarketingActivity', 'ma')
+                ->where('ma.campaign = :campaignId')
+                ->setParameter(':campaignId', $campaignId)
+                ->setMaxResults(1)
+                ->getQuery()
+                ->getSingleScalarResult();
+        } catch (\Exception $e) {
+            return false;
+        }
     }
+
 
     /**
      * @param string $entityClass


### PR DESCRIPTION
In some cases the count query can take a lot of time and need an optimization.

For example if the the marketing activity list contains a lot of items (~1M) but only a ~10 different campaigns, postgres will ignore the index generation for campaign_id. This leads to query time above 30 seconds.

This fix will not count the items but will query for the first marketing activity item for the given campaign.